### PR TITLE
Update eip-3074.md: Explain `nonce` and `chainId` better

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -231,11 +231,21 @@ More logic can be implemented around the `AUTHCALL` instruction, giving more con
 
 As originally written, this proposal specified a precompile with storage to track nonces. Since a precompile with storage is unprecedented, a revision moved replay protection into the invoker contract, necessitating a certain level of user trust in the invoker. Expanding on this idea of trusted invokers, the other signed fields were eventually eliminated, one by one, until only `invoker` and `commit` remained. To appease concerns about cross-chain replay attacks and irrevocable signatures, the `chainId` and `nonce` fields returned to the signed message.
 
+#### `invoker`
+
 The `invoker` binds a particular signed message to a single invoker. If invoker was not part of the message, any invoker could reuse the signature to completely compromise the EOA. This allows users to trust that their message will be validated as they expect, particularly the values committed to in `commit`.
 
-### Understanding `commit`
+#### `nonce`
 
-Earlier iterations of this EIP included mechanisms for replay protection, and also signed over value, gas, and other arguments to `AUTHCALL`. After further investigation, we revised this EIP to its current state: explicitly delegate these responsibilities to the invoker contract.
+Signing over the account's nonce provides a primitive way to revoke authorizations (by sending a transaction from the EOA.) See [In-Protocol Revocation](#in-protocol-revocation).
+
+#### `chainId`
+
+It is possible for an invoker to enforce that a particular signature matches the current chain (using [`CHAINID` (`0x46`)](./eip-1344.md)), but it is also possible to deploy different bytecodes to the same address on different chains (using `CREATE2` (`0xf5`)). Just because there is a well-behaved invoker on mainnet that checks the `chainId` does not mean invokers at the same address on other chains will do the same.
+
+#### `commit`
+
+Earlier iterations of this EIP signed over value, gas, and other arguments to `AUTHCALL`. After further investigation, we revised this EIP to its current state: explicitly delegate these responsibilities to the invoker contract.
 
 A user will specifically interact with an invoker they trust. Because they trust this contract to execute faithfully, they will "commit" to certain properties of a call they would like to make by computing a hash of the call values. They can be certain that the invoker will only allow the call to proceed if it is able to verify the values committed to (e.g. a nonce to protect against replay attacks). This certainty arises from the `commit` value that is signed over by the user. This is the hash of values which the invoker will validate. A safe invoker should accept the values from the user and compute the commit hash itself. This ensures that invoker operated on the same input that user authorized.
 


### PR DESCRIPTION
### Description

In this pull request, several sections in the EIP-3074 document have been modified to provide clearer explanations of the fields `invoker`, `nonce`, `chainId`, and `commit`. These changes help enhance the understanding of how these fields contribute to the security and functionality of the `AUTHCALL` instruction.

- Clarified the role of the `invoker` field in binding a signed message to a specific invoker.
- Added an explanation for the `nonce` field and its importance in providing a way to revoke authorizations.
- Introduced the `chainId` field to enforce matching signatures to the current chain.
- Detailed the purpose of the `commit` field and its significance in committing specific properties of a call.

These changes provide additional clarity and context to the functionality of the `AUTHCALL` instruction and its associated fields.