### PR TITLE
Bump rexml from 3.2.5 to 3.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.3.3)
+      strscan
     rouge (3.26.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
@@ -273,6 +274,7 @@ GEM
       faraday (>= 0.17.3, < 3)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
+    strscan (3.1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     timers (4.3.5)


### PR DESCRIPTION
### Description

The purpose of this pull request is to update the `Gemfile.lock` to modify the versions of the `rexml` and `strscan` gems.

Changes:
- Updated the `rexml` gem from version 3.2.5 to 3.3.3.
- Added the `strscan` gem with version 3.1.0.

These changes ensure that the project uses updated versions of the gems `rexml` and `strscan` with the specified versions.